### PR TITLE
Many changes...

### DIFF
--- a/src/konductor/config.py
+++ b/src/konductor/config.py
@@ -2,10 +2,14 @@
 
 from dataclasses import dataclass
 
-from .data import DatasetConfig, get_dataset_config
+from .data import DatasetConfig, get_dataset_configs
 from .init import ExperimentInitConfig
 from .losses import LossConfig, get_criterion_config
-from .models import ModelConfig, get_model_config
+from .models import (
+    ModelConfig,
+    get_model_configs,
+    unpack_model_optim_sched_from_modules,
+)
 from .optimizers import OptimizerConfig
 from .scheduler import SchedulerConfig
 
@@ -13,7 +17,7 @@ from .scheduler import SchedulerConfig
 @dataclass(slots=True)
 class ExperimentTrainConfig:
     model: list[ModelConfig]
-    dataset: DatasetConfig
+    dataset: list[DatasetConfig]
     criterion: list[LossConfig]
 
     @classmethod
@@ -23,10 +27,8 @@ class ExperimentTrainConfig:
         This will include model, dataset and criterion configurations.
         """
         return cls(
-            model=[
-                get_model_config(exp_config, i) for i in range(len(exp_config.model))
-            ],
-            dataset=get_dataset_config(exp_config),
+            model=get_model_configs(exp_config),
+            dataset=get_dataset_configs(exp_config),
             criterion=get_criterion_config(exp_config),
         )
 
@@ -38,11 +40,21 @@ class ExperimentTrainConfig:
     def scheduler(self) -> list[SchedulerConfig]:
         return [m.optimizer.scheduler for m in self.model]
 
+    def set_workers_and_prefetch(self, workers: int, prefetch: int, **kwargs):
+        """Set the number of workers and prefetch for dataloaders."""
+        for d in self.dataset:
+            d.set_workers_and_prefetch(workers, prefetch, **kwargs)
+
+    def get_training_modules(self):
+        """Return instances of training modules (model, optimizer, lr scheduler)"""
+        modules = [m.get_training_modules() for m in self.model]
+        return unpack_model_optim_sched_from_modules(modules)
+
 
 @dataclass(slots=True)
 class ExperimentEvalConfig:
-    model: ModelConfig
-    dataset: DatasetConfig
+    model: list[ModelConfig]
+    dataset: list[DatasetConfig]
 
     @classmethod
     def from_init_config(cls, exp_config: ExperimentInitConfig):
@@ -51,5 +63,5 @@ class ExperimentEvalConfig:
         This will include model, dataset and criterion configurations.
         """
         return cls(
-            model=get_model_config(exp_config), dataset=get_dataset_config(exp_config)
+            model=get_model_configs(exp_config), dataset=get_dataset_configs(exp_config)
         )

--- a/src/konductor/config.py
+++ b/src/konductor/config.py
@@ -1,8 +1,14 @@
 """Rendered configuration from ExperimentInitConfig"""
 
+import hashlib
+import logging
 from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
 
-from .data import DatasetConfig, get_dataset_configs
+import yaml
+
+from .data import DatasetConfig, Split, get_dataset_configs
 from .init import ExperimentInitConfig
 from .losses import LossConfig, get_criterion_config
 from .models import (
@@ -12,25 +18,98 @@ from .models import (
 )
 from .optimizers import OptimizerConfig
 from .scheduler import SchedulerConfig
+from .utilities import comm
+
+TRAIN_CONFIG_FILENAME = "train_config.yaml"
 
 
 @dataclass(slots=True)
-class ExperimentTrainConfig:
+class ExperimentEvalConfig:
     model: list[ModelConfig]
     dataset: list[DatasetConfig]
-    criterion: list[LossConfig]
+    init: ExperimentInitConfig
+    exp_path: Path
 
     @classmethod
-    def from_init_config(cls, exp_config: ExperimentInitConfig):
+    def from_run(cls, run_path: Path):
+        """Create an ExperimentEvalConfig from a run directory."""
+        config = ExperimentInitConfig.from_yaml(run_path / TRAIN_CONFIG_FILENAME)
+        return cls(
+            model=get_model_configs(config),
+            dataset=get_dataset_configs(config),
+            init=config,
+            exp_path=run_path,
+        )
+
+    def set_workers_and_prefetch(self, workers: int, prefetch: int = 2, **kwargs):
+        """Set the number of workers and prefetch for dataloaders."""
+        for d in self.dataset:
+            d.set_workers_and_prefetch(workers, prefetch, **kwargs)
+
+    def get_dataloader(self, split: Split, idx: int = 0):
+        """Get the dataloader for a specific dataset split."""
+        return self.dataset[idx].get_dataloader(split)
+
+    def set_batch_size(self, num: int, split: Split):
+        """Set the loaded batch size for the dataloader"""
+        for data in self.dataset:
+            match split:
+                case Split.VAL | Split.TEST:
+                    data.val_loader.batch_size = num
+                case Split.TRAIN:
+                    data.train_loader.batch_size = num
+                case _:
+                    raise ValueError(f"Invalid split {split}")
+
+    def get_batch_size(self, split: Split) -> int | list[int]:
+        """Get the batch size of the dataloader for a split"""
+        batch_size: list[int] = []
+        for data in self.dataset:
+            match split:
+                case Split.VAL | Split.TEST:
+                    batch_size.append(data.val_loader.batch_size)
+                case Split.TRAIN:
+                    batch_size.append(data.train_loader.batch_size)
+                case _:
+                    raise ValueError(f"Invalid split {split}")
+        return batch_size[0] if len(batch_size) == 1 else batch_size
+
+
+@dataclass(slots=True)
+class ExperimentTrainConfig(ExperimentEvalConfig):
+    criterion: list[LossConfig]
+
+    exp_path: Path
+
+    @classmethod
+    def from_init_config(cls, config: ExperimentInitConfig, workspace: Path):
         """
         Create an ExperimentConfig from an ExperimentInitConfig.
         This will include model, dataset and criterion configurations.
         """
+        dataset_cfg = get_dataset_configs(config)
+        exp_path = workspace / experiment_hash(config, dataset_cfg)
         return cls(
-            model=get_model_configs(exp_config),
-            dataset=get_dataset_configs(exp_config),
-            criterion=get_criterion_config(exp_config),
+            model=get_model_configs(config),
+            dataset=get_dataset_configs(config),
+            criterion=get_criterion_config(config),
+            init=config,
+            exp_path=exp_path,
         )
+
+    @classmethod
+    def from_config_file(cls, file: Path, workspace: Path):
+        """Create an ExperimentTrainConfig from a configuration file."""
+        init = ExperimentInitConfig.from_yaml(file)
+        return cls.from_init_config(init, workspace)
+
+    @classmethod
+    def from_run(cls, run_path: Path):
+        """Create an ExperimentTrainConfig from a run directory."""
+        init = ExperimentInitConfig.from_run(run_path)
+        config = cls.from_init_config(init, run_path)
+        config.exp_path = run_path  # Override to ensure consistency
+        return config
 
     @property
     def optimizer(self) -> list[OptimizerConfig]:
@@ -40,28 +119,55 @@ class ExperimentTrainConfig:
     def scheduler(self) -> list[SchedulerConfig]:
         return [m.optimizer.scheduler for m in self.model]
 
-    def set_workers_and_prefetch(self, workers: int, prefetch: int, **kwargs):
-        """Set the number of workers and prefetch for dataloaders."""
-        for d in self.dataset:
-            d.set_workers_and_prefetch(workers, prefetch, **kwargs)
+    def get_training_modules(self, idx: int = 0):
+        """Return instances of training modules (model, optimizer, lr scheduler)
+        from a model in the configuration"""
+        return self.model[idx].get_training_modules()
 
-    def get_training_modules(self):
-        """Return instances of training modules (model, optimizer, lr scheduler)"""
+    def get_all_training_modules(self):
+        """Return instances of training modules (model, optimizer, lr scheduler)
+        from all models in the configuration"""
         modules = [m.get_training_modules() for m in self.model]
         return unpack_model_optim_sched_from_modules(modules)
 
+    def create_exp_directory(self):
+        """Set the exp_path based on the workspace directory and the experiment's
+        calculated hash. Creates the directory if it doesn't exist."""
+        if not self.exp_path.exists() and comm.is_main_local_rank():
+            logging.info("Creating experiment directory %s", self.exp_path)
+            self.exp_path.mkdir(parents=True)
+        else:
+            logging.info("Using experiment directory %s", self.exp_path)
 
-@dataclass(slots=True)
-class ExperimentEvalConfig:
-    model: list[ModelConfig]
-    dataset: list[DatasetConfig]
+    def save_init_config(self):
+        """Write the experiment init config to the run_path, creating the
+        directory if it doesn't exist."""
+        self.create_exp_directory()
+        config_dict = self.init.get_dict(filter_keys={"remote_sync"})
 
-    @classmethod
-    def from_init_config(cls, exp_config: ExperimentInitConfig):
-        """
-        Create an ExperimentConfig from an ExperimentInitConfig.
-        This will include model, dataset and criterion configurations.
-        """
-        return cls(
-            model=get_model_configs(exp_config), dataset=get_dataset_configs(exp_config)
-        )
+        # Write config to run path if it doesn't already exist
+        path = self.exp_path / TRAIN_CONFIG_FILENAME
+        if not path.exists() and comm.is_main_local_rank():
+            with open(path, "w", encoding="utf-8") as conf_f:
+                yaml.safe_dump(config_dict, conf_f)
+
+        logging.info("Saved training config to %s", path)
+
+
+def experiment_hash(config: ExperimentInitConfig, datasets: list[DatasetConfig]) -> str:
+    """Returns a hash identifier for the experiment based on its init config and dataset uuids."""
+    base_config = config.get_dict(
+        filter_keys={"exp_path", "remote_sync", "checkpointer", "logger"}
+    )
+
+    ss = StringIO()
+    yaml.safe_dump(base_config, ss)
+
+    # Add uuids that exist in the dataset's folder to add uniqueness
+    for dataset_cfg in datasets:
+        if uuid := dataset_cfg.get_uuid():
+            ss.write(uuid)
+
+    ss.seek(0)
+    hash_str = hashlib.md5(ss.read().encode("utf-8")).hexdigest()
+    return hash_str

--- a/src/konductor/config.py
+++ b/src/konductor/config.py
@@ -1,0 +1,55 @@
+"""Rendered configuration from ExperimentInitConfig"""
+
+from dataclasses import dataclass
+
+from .data import DatasetConfig, get_dataset_config
+from .init import ExperimentInitConfig
+from .losses import LossConfig, get_criterion_config
+from .models import ModelConfig, get_model_config
+from .optimizers import OptimizerConfig
+from .scheduler import SchedulerConfig
+
+
+@dataclass(slots=True)
+class ExperimentTrainConfig:
+    model: list[ModelConfig]
+    dataset: DatasetConfig
+    criterion: list[LossConfig]
+
+    @classmethod
+    def from_init_config(cls, exp_config: ExperimentInitConfig):
+        """
+        Create an ExperimentConfig from an ExperimentInitConfig.
+        This will include model, dataset and criterion configurations.
+        """
+        return cls(
+            model=[
+                get_model_config(exp_config, i) for i in range(len(exp_config.model))
+            ],
+            dataset=get_dataset_config(exp_config),
+            criterion=get_criterion_config(exp_config),
+        )
+
+    @property
+    def optimizer(self) -> list[OptimizerConfig]:
+        return [m.optimizer for m in self.model]
+
+    @property
+    def scheduler(self) -> list[SchedulerConfig]:
+        return [m.optimizer.scheduler for m in self.model]
+
+
+@dataclass(slots=True)
+class ExperimentEvalConfig:
+    model: ModelConfig
+    dataset: DatasetConfig
+
+    @classmethod
+    def from_init_config(cls, exp_config: ExperimentInitConfig):
+        """
+        Create an ExperimentConfig from an ExperimentInitConfig.
+        This will include model, dataset and criterion configurations.
+        """
+        return cls(
+            model=get_model_config(exp_config), dataset=get_dataset_config(exp_config)
+        )

--- a/src/konductor/data/__init__.py
+++ b/src/konductor/data/__init__.py
@@ -155,9 +155,21 @@ def get_dataset_configs(config: ExperimentInitConfig) -> list[DatasetConfig]:
     return [get_dataset_config(config, i) for i in range(len(config.dataset))]
 
 
-def get_dataset_properties(config: ExperimentInitConfig) -> dict[str, Any]:
+def get_dataset_properties(
+    config: ExperimentInitConfig | list[DatasetConfig] | DatasetConfig,
+) -> dict[str, Any]:
     """Get properties of all datasets in experiment"""
     properties = {}
-    for ds_config in get_dataset_configs(config):
-        properties.update(ds_config.properties)
+    if isinstance(config, ExperimentInitConfig):
+        for ds_config in get_dataset_configs(config):
+            properties.update(ds_config.properties)
+    elif isinstance(config, list):
+        for ds_config in config:
+            properties.update(ds_config.properties)
+    elif isinstance(config, DatasetConfig):
+        properties.update(config.properties)
+    else:
+        raise TypeError(
+            "config must be ExperimentInitConfig, DatasetConfig or list of DatasetConfig"
+        )
     return properties

--- a/src/konductor/data/__init__.py
+++ b/src/konductor/data/__init__.py
@@ -24,13 +24,23 @@ class DataloaderConfig(BaseConfig):
 
     batch_size: int
     workers: int = 0
+    prefetch: int = 2
     shuffle: bool = False
     drop_last: bool = True
-    augmentations: list[ModuleInitConfig] = field(default_factory=lambda: [])
+    augmentations: list[ModuleInitConfig] = field(default_factory=list)
 
     @classmethod
     def from_config(cls, *args, **kwargs) -> Any:
         return cls(*args, **kwargs)
+
+    def set_workers_and_prefetch(self, workers: int, prefetch: int, **kwargs):
+        """Set dataloader worker and prefetch settings"""
+        self.workers = workers
+        self.prefetch = prefetch
+        if kwargs:
+            logging.getLogger(type(self).__name__).warning(
+                "DALI dataloader does not support setting %s", ", ".join(kwargs.keys())
+            )
 
 
 @dataclass
@@ -57,16 +67,10 @@ class DatasetConfig(BaseConfig):
         :param idx: Index of the dataset to be configured, defaults to 0
         :return: Returns a dataset configuration.
         """
-        data_cfg = config.data[idx]
-        train_loader = DATALOADER_REGISTRY[data_cfg.train_loader.type](
-            **data_cfg.train_loader.args
-        )
-        val_loader = DATALOADER_REGISTRY[data_cfg.val_loader.type](
-            **data_cfg.val_loader.args
-        )
-        return cls(
-            train_loader=train_loader, val_loader=val_loader, **data_cfg.dataset.args
-        )
+        data_cfg = config.dataset[idx]
+        train_loader = DATALOADER_REGISTRY[data_cfg.loader_type](**data_cfg.train_args)
+        val_loader = DATALOADER_REGISTRY[data_cfg.loader_type](**data_cfg.val_args)
+        return cls(train_loader=train_loader, val_loader=val_loader, **data_cfg.args)
 
     @property
     def properties(self) -> dict[str, Any]:
@@ -85,6 +89,22 @@ class DatasetConfig(BaseConfig):
         """Redirect to get_dataloader"""
         warn("get_dataloader should be used with split argument")
         return self.get_dataloader(*args, **kwargs)
+
+    def get_uuid(self) -> str | None:
+        """Get the uuid of the dataset if it exists.
+        The default implementation assumes this is a 'uuid' file in the dataset's basepath
+        """
+        uuid_path = self.basepath / "uuid"
+        if uuid_path.exists():
+            return uuid_path.read_text().strip()
+        return None
+
+    def set_dataloader_workers_and_prefetch(
+        self, workers: int, prefetch: int, **kwargs
+    ):
+        """Set dataloader worker and prefetch settings for both train and validation loaders"""
+        for loader in [self.train_loader, self.val_loader]:
+            loader.set_workers_and_prefetch(workers, prefetch, **kwargs)
 
 
 try:
@@ -119,26 +139,22 @@ if _check_framework("tensorflow"):
 
 def make_from_init_config(config: DatasetInitConfig) -> DatasetConfig:
     """Create dataset config from init config"""
-    dataset_config = DATASET_REGISTRY[config.dataset.type](
-        train_loader=DATALOADER_REGISTRY[config.train_loader.type](
-            **config.train_loader.args
-        ),
-        val_loader=DATALOADER_REGISTRY[config.val_loader.type](
-            **config.val_loader.args
-        ),
-        **config.dataset.args,
+    dataset_config = DATASET_REGISTRY[config.type](
+        train_loader=DATALOADER_REGISTRY[config.loader_type](**config.train_args),
+        val_loader=DATALOADER_REGISTRY[config.loader_type](**config.val_args),
+        **config.args,
     )
     return dataset_config
 
 
 def get_dataset_config(config: ExperimentInitConfig, idx: int = 0) -> DatasetConfig:
     """Get dataset configuration at index"""
-    return DATASET_REGISTRY[config.data[idx].dataset.type].from_config(config, idx)
+    return DATASET_REGISTRY[config.dataset[idx].type].from_config(config, idx)
 
 
 def get_dataset_properties(config: ExperimentInitConfig) -> dict[str, Any]:
     """Get properties of all datasets in experiment"""
     properties = {}
-    for idx in range(len(config.data)):
+    for idx in range(len(config.dataset)):
         properties.update(get_dataset_config(config, idx).properties)
     return properties

--- a/src/konductor/data/__init__.py
+++ b/src/konductor/data/__init__.py
@@ -99,9 +99,7 @@ class DatasetConfig(BaseConfig):
             return uuid_path.read_text().strip()
         return None
 
-    def set_dataloader_workers_and_prefetch(
-        self, workers: int, prefetch: int, **kwargs
-    ):
+    def set_workers_and_prefetch(self, workers: int, prefetch: int, **kwargs):
         """Set dataloader worker and prefetch settings for both train and validation loaders"""
         for loader in [self.train_loader, self.val_loader]:
             loader.set_workers_and_prefetch(workers, prefetch, **kwargs)
@@ -152,9 +150,14 @@ def get_dataset_config(config: ExperimentInitConfig, idx: int = 0) -> DatasetCon
     return DATASET_REGISTRY[config.dataset[idx].type].from_config(config, idx)
 
 
+def get_dataset_configs(config: ExperimentInitConfig) -> list[DatasetConfig]:
+    """Get all dataset configurations"""
+    return [get_dataset_config(config, i) for i in range(len(config.dataset))]
+
+
 def get_dataset_properties(config: ExperimentInitConfig) -> dict[str, Any]:
     """Get properties of all datasets in experiment"""
     properties = {}
-    for idx in range(len(config.dataset)):
-        properties.update(get_dataset_config(config, idx).properties)
+    for ds_config in get_dataset_configs(config):
+        properties.update(ds_config.properties)
     return properties

--- a/src/konductor/data/_pytorch/dataloader.py
+++ b/src/konductor/data/_pytorch/dataloader.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from logging import warning
 from typing import Any, Callable, Type
 
 from torch.utils.data import (
@@ -9,25 +8,12 @@ from torch.utils.data import (
     RandomSampler,
     Sampler,
     SequentialSampler,
-    default_collate,
 )
 
 from ...utilities.comm import get_world_size, in_distributed_mode
 from .. import DATALOADER_REGISTRY, DataloaderConfig, Registry
 
 DATAPIPE_AUG = Registry("datapipe_augmentations")
-
-try:
-    from torchdata.dataloader2 import DataLoader2
-    from torchdata.dataloader2.reading_service import (
-        DistributedReadingService,
-        MultiProcessingReadingService,
-        SequentialReadingService,
-    )
-    from torchdata.datapipes.iter import IterableWrapper
-    from torchdata.datapipes.utils import pin_memory_fn
-except ImportError:
-    warning("torchdata unavailable")
 
 
 @dataclass
@@ -70,50 +56,5 @@ class DataloaderV1Config(DataloaderConfig):
             num_workers=self.workers,
             pin_memory=self.pin_memory,
             collate_fn=self.collate_fn,
+            prefetch_factor=self.prefetch,
         )
-
-
-@dataclass
-@DATALOADER_REGISTRY.register_module("PYTORCH_V2")
-class DataloaderV2Config(DataloaderConfig):
-    """PyTorch DataPipe API Dataloader"""
-
-    pin_memory: bool = True
-
-    def get_instance(self, dataset):
-        datapipe = IterableWrapper(dataset)
-
-        if self.shuffle:
-            datapipe = datapipe.shuffle()
-        if in_distributed_mode():
-            datapipe = datapipe.sharding_filter()
-
-        # TODO figure out conditions when jit can be used.
-        # Can't use jit for multi-worker datapipe, many transforms can't be jit either.
-        # if len(self.augmentations) > 0:
-        #     transforms = torch.nn.Sequential(
-        #         *list(DATAPIPE_AUG[aug.type](**aug.args) for aug in self.augmentations)
-        #     )
-        #     datapipe = datapipe.map(torch.jit.script(transforms))
-
-        for aug in self.augmentations:
-            datapipe = datapipe.map(DATAPIPE_AUG[aug.type](**aug.args))
-
-        datapipe = datapipe.batch(self.batch_size).map(default_collate)
-
-        if self.pin_memory:
-            datapipe = datapipe.map(pin_memory_fn)
-
-        if self.workers > 0 and in_distributed_mode():
-            rs = SequentialReadingService(
-                DistributedReadingService(),
-                MultiProcessingReadingService(num_workers=self.workers),
-            )
-        elif in_distributed_mode():
-            rs = DistributedReadingService()
-        elif self.workers > 0:
-            rs = MultiProcessingReadingService(num_workers=self.workers)
-        else:
-            rs = None
-
-        return DataLoader2(datapipe, reading_service=rs)

--- a/src/konductor/data/_pytorch/dataloader.py
+++ b/src/konductor/data/_pytorch/dataloader.py
@@ -17,9 +17,9 @@ DATAPIPE_AUG = Registry("datapipe_augmentations")
 
 
 @dataclass
-@DATALOADER_REGISTRY.register_module("PYTORCH_V1")
-class DataloaderV1Config(DataloaderConfig):
-    """Original PyTorch Dataset Dataloader"""
+@DATALOADER_REGISTRY.register_module("PYTORCH")
+class TorchLoaderConfig(DataloaderConfig):
+    """PyTorch Dataset Dataloader"""
 
     pin_memory: bool = True
     sampler: Type[Sampler] | None = None
@@ -58,3 +58,6 @@ class DataloaderV1Config(DataloaderConfig):
             collate_fn=self.collate_fn,
             prefetch_factor=self.prefetch,
         )
+
+
+DATALOADER_REGISTRY.register_module("PYTORCH_V1", TorchLoaderConfig)  # Backcompat

--- a/src/konductor/data/dali.py
+++ b/src/konductor/data/dali.py
@@ -24,8 +24,8 @@ DALI_AUGMENTATIONS = Registry("DALI_AUGMENTATIONS")
 class DaliLoaderConfig(DataloaderConfig):
     """DALI Dataloader configuration"""
 
-    py_num_workers: int = 1
-    prefetch_queue_depth: int = 2
+    py_workers: int = 1
+    source_prefetch: int = 1
 
     def pipe_kwargs(self):
         """Common keyword arguments used for pipeline definition"""
@@ -37,8 +37,8 @@ class DaliLoaderConfig(DataloaderConfig):
             "batch_size": self.batch_size // get_world_size(),
             "augmentations": self.augmentations,
             "random_shuffle": self.shuffle,
-            "py_num_workers": self.py_num_workers,
-            "prefetch_queue_depth": self.prefetch_queue_depth,
+            "py_num_workers": self.py_workers,
+            "prefetch_queue_depth": self.prefetch,
         }
 
     def get_instance(
@@ -63,6 +63,17 @@ class DaliLoaderConfig(DataloaderConfig):
             auto_reset=True,
             last_batch_policy=last_batch,
         )
+
+    def set_workers_and_prefetch(self, workers: int, prefetch: int, **kwargs):
+        self.workers = workers
+        self.prefetch = prefetch
+        self.source_prefetch = kwargs.get("source_prefetch", self.source_prefetch)
+        self.py_workers = kwargs.get("py_workers", self.py_workers)
+        unknown_keys = set(kwargs.keys()) - {"source_prefetch", "py_workers"}
+        if unknown_keys:
+            getLogger(type(self).__name__).warning(
+                "DALI dataloader does not support setting %s", ", ".join(unknown_keys)
+            )
 
 
 @dataclass

--- a/src/konductor/metadata/manager.py
+++ b/src/konductor/metadata/manager.py
@@ -9,6 +9,7 @@ import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from logging import getLogger
+from pathlib import Path
 from typing import Any
 
 from ..init import ExperimentInitConfig
@@ -121,6 +122,7 @@ class DataManager:
     @classmethod
     def default_build(
         cls,
+        logdir: Path,
         exp_config: ExperimentInitConfig,
         checkpointables: dict[str, Any],
         statistics: dict[str, Statistic],
@@ -133,15 +135,10 @@ class DataManager:
         PerfLogger initialized with given statistics, if log_writer is
         None the bundled parquet logging backend is used.
         """
-        assert (
-            exp_config.exp_path is not None
-        ), "Experiment path must be set in exp_config"
         remote_sync = None if exp_config.remote_sync is None else get_remote(exp_config)
-
-        checkpointer = Checkpointer(exp_config.exp_path, **checkpointables)
-
+        checkpointer = Checkpointer(logdir, **checkpointables)
         if log_writer is None:
-            log_writer = ParquetLogger(exp_config.exp_path)
+            log_writer = ParquetLogger(logdir)
         perf_logger = PerfLogger(log_writer, statistics, **exp_config.logger)
 
         return cls(

--- a/src/konductor/metadata/manager.py
+++ b/src/konductor/metadata/manager.py
@@ -85,16 +85,20 @@ class CkptConfig:
 
     @property
     def epoch_mode(self):
+        """The checkpointer should save at epoch intervals"""
         return self.mode is CkptConfig.Mode.EPOCH
 
     @property
     def iter_mode(self):
+        """The checkpointer should save at iteration intervals"""
         return self.mode is CkptConfig.Mode.ITERATION
 
     def save_latest(self, x: int):
+        """Check if the latest checkpoint should be saved"""
         return x % self.latest == 0
 
     def save_extra(self, x: int):
+        """Check if the extra checkpoint interval should be saved"""
         return self.extra is not None and x % self.extra == 0
 
 
@@ -129,6 +133,9 @@ class DataManager:
         PerfLogger initialized with given statistics, if log_writer is
         None the bundled parquet logging backend is used.
         """
+        assert (
+            exp_config.exp_path is not None
+        ), "Experiment path must be set in exp_config"
         remote_sync = None if exp_config.remote_sync is None else get_remote(exp_config)
 
         checkpointer = Checkpointer(exp_config.exp_path, **checkpointables)

--- a/src/konductor/trainer/pytorch.py
+++ b/src/konductor/trainer/pytorch.py
@@ -332,7 +332,7 @@ class PyTorchTrainer(BaseTrainer):
         """
         with record_function("statistics"):
             if losses is not None:
-                if isinstance(self.modules.scheduler, list):
+                if len(self.modules.scheduler) > 1:
                     loss_lrs = {
                         f"lr_{s}_{i}": lr
                         for s, scheduler in enumerate(self.modules.scheduler)
@@ -341,7 +341,7 @@ class PyTorchTrainer(BaseTrainer):
                 else:
                     loss_lrs = {
                         f"lr_{i}": lr
-                        for i, lr in enumerate(self.modules.scheduler.get_last_lr())
+                        for i, lr in enumerate(self.modules.scheduler[0].get_last_lr())
                     }
                 loss_lrs.update(losses)  # Copy losses
                 self.data_manager.perflog.log("loss", loss_lrs)

--- a/src/konductor/trainer/trainer.py
+++ b/src/konductor/trainer/trainer.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, fields
 from logging import getLogger
 from typing import Any, Callable, Sequence, TypeVar
 
+from ..config import ExperimentTrainConfig
 from ..data import Split, get_dataset_config
 from ..init import ExperimentInitConfig
 from ..losses import get_criterion
@@ -42,6 +43,10 @@ class TrainerModules:
         criterion = get_criterion(exp_config)
 
         return cls(models, criterion, optims, scheds, train_loaders, val_loaders)
+
+    @classmethod
+    def from_train_config(cls, cfg: ExperimentTrainConfig):
+        raise NotImplementedError()
 
     def __post_init__(self):
         # Remove list wrapper if only one model/dataset etc

--- a/src/konductor/trainer/trainer.py
+++ b/src/konductor/trainer/trainer.py
@@ -68,7 +68,7 @@ class TrainerModules:
         # Get train and val dataloaders
         train_loaders = _get_dataloader_from_dataset_configs(cfg.dataset, Split.TRAIN)
         val_loaders = _get_dataloader_from_dataset_configs(cfg.dataset, Split.VAL)
-        models, optims, scheds = cfg.get_training_modules()
+        models, optims, scheds = cfg.get_all_training_modules()
         criterion = [c.get_instance() for c in cfg.criterion]
         return cls(models, criterion, optims, scheds, train_loaders, val_loaders)
 

--- a/src/konductor/utilities/comm/_pytorch.py
+++ b/src/konductor/utilities/comm/_pytorch.py
@@ -76,6 +76,11 @@ def is_main_process() -> bool:
     return get_rank() == 0
 
 
+def is_main_local_rank() -> bool:
+    """Return if main process in local (per-machine) group"""
+    return get_local_rank() == 0
+
+
 def synchronize():
     """
     Helper function to synchronize (barrier) among all processes when

--- a/src/konductor/webserver/utils.py
+++ b/src/konductor/webserver/utils.py
@@ -2,7 +2,6 @@ import re
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
-from logging import debug
 from pathlib import Path
 from typing import Deque
 
@@ -10,7 +9,7 @@ import pandas as pd
 import yaml
 from pyarrow import parquet as pq
 
-from konductor.init import TRAIN_CONFIG_FILENAME
+from konductor.config import TRAIN_CONFIG_FILENAME
 from konductor.metadata.database.metadata import DEFAULT_FILENAME as METADATA_FILENAME
 from konductor.utilities.metadata import _PQ_REDUCED_RE
 

--- a/tests/base_old.yaml
+++ b/tests/base_old.yaml
@@ -13,10 +13,11 @@ model:
 dataset:
   - type: MNIST
     args: {}
-    loader_type: PYTORCH_V1
-    loader_args:
-      batch_size: 32
-      workers: 8
+    loader:
+      type: PYTORCH_V1
+      args:
+        batch_size: 32
+        workers: 8
 criterion:
   - type: ce
     args: {}

--- a/tests/config_init/test_pytorch.py
+++ b/tests/config_init/test_pytorch.py
@@ -1,7 +1,10 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 from torch import nn
 
+from konductor.config import ExperimentTrainConfig
 from konductor.init import ExperimentInitConfig
 from konductor.models import get_training_model
 from konductor.optimizers._pytorch import PG_REGISTRY
@@ -19,6 +22,16 @@ def _custom_pg_fn(model: nn.Module, lr, arg, **kwargs):
         else:
             pgs[1]["params"].append(param)
     return pgs
+
+
+def test_back_compat_loader():
+    """Test that old dataset configuration is still supported"""
+    ExperimentInitConfig.from_config(Path(__file__).parent.parent / "base_old.yaml")
+
+
+def test_train_config_from_init(example_config: ExperimentInitConfig):
+    """Test current training config can be created"""
+    train_config = ExperimentTrainConfig.from_init_config(example_config)
 
 
 def test_optim_param_groups(example_config: ExperimentInitConfig):

--- a/tests/init_config.py
+++ b/tests/init_config.py
@@ -8,11 +8,6 @@ from konductor.init import ExperimentInitConfig
 @pytest.fixture
 def example_config(tmp_path):
     """Setup example experiment and path to scratch"""
-    config = ExperimentInitConfig.from_config(
-        tmp_path, config_path=Path(__file__).parent / "base.yaml"
-    )
-
-    if not config.exp_path.exists():
-        config.exp_path.mkdir()
-
+    config = ExperimentInitConfig.from_config(Path(__file__).parent / "base.yaml")
+    config.write_config(tmp_path)
     return config

--- a/tests/init_config.py
+++ b/tests/init_config.py
@@ -2,12 +2,21 @@ from pathlib import Path
 
 import pytest
 
+from konductor.config import ExperimentTrainConfig
 from konductor.init import ExperimentInitConfig
 
 
 @pytest.fixture
-def example_config(tmp_path):
+def init_cfg():
+    """Get example initialization configuration."""
+    config = ExperimentInitConfig.from_yaml(Path(__file__).parent / "base.yaml")
+    return config
+
+
+@pytest.fixture
+def train_cfg(tmp_path):
     """Setup example experiment and path to scratch"""
-    config = ExperimentInitConfig.from_config(Path(__file__).parent / "base.yaml")
-    config.write_config(tmp_path)
+    config = ExperimentTrainConfig.from_config_file(
+        Path(__file__).parent / "base.yaml", workspace=tmp_path
+    )
     return config

--- a/tests/remote/test_remote.py
+++ b/tests/remote/test_remote.py
@@ -4,30 +4,31 @@ from pathlib import Path
 
 import pytest
 
-from konductor.init import ExperimentInitConfig, ModuleInitConfig
+from konductor.config import ExperimentTrainConfig
+from konductor.init import ModuleInitConfig
 from konductor.metadata.remotesync import get_remote
 
-from ..init_config import example_config
+from ..init_config import init_cfg
 
 pytestmark = pytest.mark.remote
 
 
-def test_remote_ssh_pk(example_config: ExperimentInitConfig):
+def test_remote_ssh_pk(init_cfg: ExperimentTrainConfig):
     """ """
     pk_config = {
         "key_filename": str(Path.home() / ".ssh/id_rsa"),
         "username": "worker",
         "hostname": "127.0.0.1",
     }
-    example_config.remote_sync = ModuleInitConfig(
+    init_cfg.init.remote_sync = ModuleInitConfig(
         type="ssh", args={"pk_cfg": pk_config, "remote_path": "/tmp"}
     )
-    remote = get_remote(example_config)
+    remote = get_remote(init_cfg.init)
 
 
-def test_remote_ssh_file(example_config: ExperimentInitConfig):
+def test_remote_ssh_file(init_cfg: ExperimentTrainConfig):
     """ """
-    example_config.remote_sync = ModuleInitConfig(
+    init_cfg.init.remote_sync = ModuleInitConfig(
         type="ssh",
         args={
             "filepath": Path(__file__).parent / "ssh_config",
@@ -35,10 +36,10 @@ def test_remote_ssh_file(example_config: ExperimentInitConfig):
             "remote_path": "/tmp",
         },
     )
-    remote = get_remote(example_config)
+    remote = get_remote(init_cfg.init)
 
 
-def test_remote_minio(example_config_path: ExperimentInitConfig):
-    cfg = example_config_path
-    cfg.remote_sync = ModuleInitConfig(type="minio", args={})
-    remote = get_remote(cfg)
+def test_remote_minio(init_cfg: ExperimentTrainConfig):
+    cfg = init_cfg
+    cfg.init.remote_sync = ModuleInitConfig(type="minio", args={})
+    remote = get_remote(cfg.init)

--- a/tests/statistics/test_pqlogger.py
+++ b/tests/statistics/test_pqlogger.py
@@ -24,12 +24,9 @@ def test_basic_writer_usage(pq_writer: _ParquetWriter):
     assert not pq_writer.empty
     assert "some_data" in pq_writer._columns
     assert "other_data" not in pq_writer._columns
-
-    with pytest.raises(KeyError):
-        pq_writer(1, {"other_data": 100})
-
     pq_writer(1, {"some_data": 20.0})
-    assert pq_writer.size == 2
+    pq_writer(2, {"other_data": 100})
+    assert pq_writer.size == 3
 
 
 def test_logger_files(pq_logger: ParquetLogger):

--- a/tests/trainer/test_e2e.py
+++ b/tests/trainer/test_e2e.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.e2e
 def trainer(tmp_path):
     cfg = ExperimentInitConfig.from_config(Path(__file__).parent.parent / "base.yaml")
     cfg.write_config(tmp_path)
-    train_modules = PyTorchTrainerModules.from_config(cfg)
+    train_modules = PyTorchTrainerModules.from_init_config(cfg)
     data_manager = DataManager.default_build(
         cfg, train_modules.get_checkpointables(), statistics={"acc": Accuracy()}
     )

--- a/tests/trainer/test_e2e.py
+++ b/tests/trainer/test_e2e.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.e2e
 
 @pytest.fixture
 def trainer(tmp_path):
-    cfg = ExperimentInitConfig.from_config(Path(__file__).parent.parent / "base.yaml")
+    cfg = ExperimentInitConfig.from_yaml(Path(__file__).parent.parent / "base.yaml")
     cfg.write_config(tmp_path)
     train_modules = PyTorchTrainerModules.from_init_config(cfg)
     data_manager = DataManager.default_build(

--- a/tests/trainer/test_e2e.py
+++ b/tests/trainer/test_e2e.py
@@ -13,9 +13,8 @@ pytestmark = pytest.mark.e2e
 
 @pytest.fixture
 def trainer(tmp_path):
-    cfg = ExperimentInitConfig.from_config(
-        workspace=tmp_path, config_path=Path(__file__).parent.parent / "base.yaml"
-    )
+    cfg = ExperimentInitConfig.from_config(Path(__file__).parent.parent / "base.yaml")
+    cfg.write_config(tmp_path)
     train_modules = PyTorchTrainerModules.from_config(cfg)
     data_manager = DataManager.default_build(
         cfg, train_modules.get_checkpointables(), statistics={"acc": Accuracy()}

--- a/tests/trainer/test_ema.py
+++ b/tests/trainer/test_ema.py
@@ -43,6 +43,7 @@ def trainer(tmp_path):
 def test_ema_functionality(trainer: PyTorchTrainer):
     """Check that EMA is updating during training, its state dict is saved
     correctly, and it can be loaded correctly"""
+    assert trainer.modules.model_ema is not None, "Model EMA should be initialized"
     initial_ema = deepcopy(trainer.modules.model_ema.state_dict())
     trainer.train(epoch=3)
     current_ema = deepcopy(trainer.modules.model_ema.state_dict())

--- a/tests/trainer/test_ema.py
+++ b/tests/trainer/test_ema.py
@@ -28,8 +28,8 @@ def trainer(tmp_path):
     modules = PyTorchTrainerModules(
         model,
         [TrivialLoss()],
-        optim,
-        PolyLRConfig(max_iter=10).get_instance(optimizer=optim),
+        [optim],
+        [PolyLRConfig(max_iter=10).get_instance(optimizer=optim)],
         DataLoader(TensorDataset(*make_dataset(32)), batch_size=8),
         DataLoader(TensorDataset(*make_dataset(8)), batch_size=4),
     )


### PR DESCRIPTION
- Added rendered configuration dataclasses (`ExperimentEvalConfig` and `ExperimentTrainConfig`) to avoid having to repeatably use `get_dataset_config` or `get_model_config` throughout training/eval code pipelines and separate out the workspace directory from the `ExperimentInitConfig`.
- Added uuid property to dataset which is fused with the config hash if available to make the training hash unique for both the config and dataset being trained on.
- Properly handle multi-optimizer/scheduler/dataloader training pipelines.
- Remove torch datapipe since it's been depricated/undepricated, bit of a mess.
- Added api for dataloader worker+prefetch setting.
- Adjusted `DatasetConfig` dataclasses to reduce redundancies and config depth.